### PR TITLE
Issue [#2]: Add ability to purchase items from player to player

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 
 ## Overview
 
-This application is my first experience with using both GraphQL and MariaDB. The application comprises a simple domain
-model of `Player` entities and `Item` entities. These entities are stored in MariaDB and then retrievable using GraphQL.
+This application has been developed as an introduction to both GraphQL and document storage using Elasticsearch.
+
+## Technology Stack
+
+- JDK 17
+- MariaDB for database persistence
+- Flyway for database migration management
+- Elasticsearch for archival marketplace transaction receipt storage
 
 ## Prerequisites
 
@@ -33,10 +39,18 @@ application.
    items
    into the MariaDB database
 
+### Running Elasticsearch
+
+1) Lastly as a pre-requisite, use `docker-compose up -d` in the `docker/elasticsearch` directory to launch an instance
+   of Elasticsearch running on port 9200. 
+
 ### Building the graphql-test application
 
-1) Again, at the project root, use the command `docker build -t graphql_test .` in order to build this application as
-   a Docker image
+**Note:**  Integration tests will currently only work with seed data inserted using Flyway migrations. It is intended
+in the future that the use of Testcontainers will remedy this. 
+
+1) Again, at the project root, use the command `mvn clean install && cd target && docker build -t graphql_test .` in 
+   order to build this application as a Docker image
 2) Once the image has been built successfully you may now use the `docker-compose.yml` within `docker/graphql_test` to
    launch the application, again with `docker-compose up -d`, on port 8080.
 
@@ -46,15 +60,11 @@ The application contains GraphiQL as a dependency which may be used to quickly t
 additional installation of tools. By default, this is accessible at **http://localhost:8080/graphiql**
 
 From this interface you are able to see the available `Query` and `Mutation` types, along with the configurable response
-entities. There are 3 available interactions:
-
-- List all current players (allPlayers)
-- List all items for a particular (allPlayerItems)
-- Add a new player (addPlayer)
+entities. There are 8 available interactions viewable in `resources/graphql/schema.graphqls`
 
 Using the left-hand pane of GraphiDQL you can enter your queries.
 
-## Example
+## Example - Retrieving all players 
 
 The following query:
 
@@ -73,7 +83,7 @@ query {
 }
 ```
 
-when run with the included seed data will return the following JSON output:
+when run with the included seed data will return all the list of players inserted using Flyway:
 
 ```json
 {

--- a/docker/elasticsearch/app.env
+++ b/docker/elasticsearch/app.env
@@ -1,0 +1,1 @@
+ELASTIC_SEARCH_HOST:elasticsearch

--- a/docker/elasticsearch/docker-compose.yml
+++ b/docker/elasticsearch/docker-compose.yml
@@ -9,6 +9,12 @@ services:
       - 9200:9200
     environment:
       - discovery.type=single-node
+    networks:
+      - graphql_test
+
+networks:
+  graphql_test:
+    external: true
 
 volumes:
   elasticsearch:

--- a/docker/elasticsearch/docker-compose.yml
+++ b/docker/elasticsearch/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     image: elasticsearch:7.8.0
     hostname: elasticsearch
     container_name: elasticsearch
+    env_file:
+      - app.env
     ports:
       - 9200:9200
     environment:

--- a/docker/elasticsearch/docker-compose.yml
+++ b/docker/elasticsearch/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.9'
+
+services:
+  elasticsearch:
+    image: elasticsearch:7.8.0
+    hostname: elasticsearch
+    container_name: elasticsearch
+    ports:
+      - 9200:9200
+    environment:
+      - discovery.type=single-node
+
+volumes:
+  elasticsearch:

--- a/docker/mariadb/docker-compose.yml
+++ b/docker/mariadb/docker-compose.yml
@@ -17,6 +17,9 @@ services:
     networks:
     - graphql_test
 
+volumes:
+  mariadb:
+
 networks:
   graphql_test:
     external: true

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>graphiql-spring-boot-starter</artifactId>
             <version>${graphql-spring-boot-starter.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-elasticsearch</artifactId>
+            <version>${spring-data-elasticsearch-version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -96,7 +101,7 @@
         <spring-boot-starter-web-version>2.6.7</spring-boot-starter-web-version>
         <maria-db-java-client-version>3.0.4</maria-db-java-client-version>
         <graphql-spring-boot-starter-test-version>5.0.4</graphql-spring-boot-starter-test-version>
-
+        <spring-data-elasticsearch-version>4.0.0.RELEASE</spring-data-elasticsearch-version>
         <!--flyway properties-->
         <flyway-maven-plugin-version>8.2.0</flyway-maven-plugin-version>
         <database-username>root</database-username>

--- a/src/main/java/com/amido/graphqltest/GraphqlTestApplication.java
+++ b/src/main/java/com/amido/graphqltest/GraphqlTestApplication.java
@@ -1,10 +1,15 @@
 package com.amido.graphqltest;
 
+import com.amido.graphqltest.properties.ElasticsearchProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 
 @SpringBootApplication
+@EnableConfigurationProperties(value = {
+        ElasticsearchProperties.class
+})
 public class GraphqlTestApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/amido/graphqltest/configuration/ClockConfiguration.java
+++ b/src/main/java/com/amido/graphqltest/configuration/ClockConfiguration.java
@@ -1,0 +1,16 @@
+package com.amido.graphqltest.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+
+@Configuration
+public class ClockConfiguration {
+
+    @Bean
+    public Clock clock(){
+        return Clock.systemDefaultZone();
+    }
+
+}

--- a/src/main/java/com/amido/graphqltest/configuration/ClockConfiguration.java
+++ b/src/main/java/com/amido/graphqltest/configuration/ClockConfiguration.java
@@ -9,7 +9,7 @@ import java.time.Clock;
 public class ClockConfiguration {
 
     @Bean
-    public Clock clock(){
+    public Clock clock() {
         return Clock.systemDefaultZone();
     }
 

--- a/src/main/java/com/amido/graphqltest/configuration/ElasticsearchConfiguration.java
+++ b/src/main/java/com/amido/graphqltest/configuration/ElasticsearchConfiguration.java
@@ -1,5 +1,7 @@
 package com.amido.graphqltest.configuration;
 
+import com.amido.graphqltest.properties.ElasticsearchProperties;
+import lombok.RequiredArgsConstructor;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,13 +13,16 @@ import org.springframework.data.elasticsearch.repository.config.EnableElasticsea
 
 @Configuration
 @EnableElasticsearchRepositories(basePackages = "com.amido.graphqltest.repository")
+@RequiredArgsConstructor
 public class ElasticsearchConfiguration {
+
+    private final ElasticsearchProperties elasticsearchProperties;
 
     @Bean
     public RestHighLevelClient client() {
-        ClientConfiguration clientConfiguration
+        final ClientConfiguration clientConfiguration
                 = ClientConfiguration.builder()
-                .connectedTo("localhost:9200")
+                .connectedTo(String.join(":", elasticsearchProperties.getHost()), elasticsearchProperties.getPort())
                 .build();
 
         return RestClients.create(clientConfiguration).rest();

--- a/src/main/java/com/amido/graphqltest/configuration/ElasticsearchConfiguration.java
+++ b/src/main/java/com/amido/graphqltest/configuration/ElasticsearchConfiguration.java
@@ -1,0 +1,30 @@
+package com.amido.graphqltest.configuration;
+
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.RestClients;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories(basePackages = "com.amido.graphqltest.repository")
+public class ElasticsearchConfiguration {
+
+    @Bean
+    public RestHighLevelClient client() {
+        ClientConfiguration clientConfiguration
+                = ClientConfiguration.builder()
+                .connectedTo("localhost:9200")
+                .build();
+
+        return RestClients.create(clientConfiguration).rest();
+    }
+
+    @Bean
+    public ElasticsearchOperations elasticsearchTemplate() {
+        return new ElasticsearchRestTemplate(client());
+    }
+}

--- a/src/main/java/com/amido/graphqltest/configuration/IdSupplierConfiguration.java
+++ b/src/main/java/com/amido/graphqltest/configuration/IdSupplierConfiguration.java
@@ -1,0 +1,17 @@
+package com.amido.graphqltest.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
+@Configuration
+public class IdSupplierConfiguration {
+
+    @Bean
+    public Supplier<UUID> uuidSupplier() {
+        return UUID::randomUUID;
+    }
+
+}

--- a/src/main/java/com/amido/graphqltest/domain/Item.java
+++ b/src/main/java/com/amido/graphqltest/domain/Item.java
@@ -1,11 +1,15 @@
 package com.amido.graphqltest.domain;
 
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import javax.persistence.*;
 import java.util.List;
 
-@Data
+@Getter
+@Setter
 @Entity
 @Table(name = "items")
 public class Item {
@@ -15,6 +19,7 @@ public class Item {
     private String name;
     private String effect;
 
+    @ToString.Exclude
     @ManyToMany(
             fetch = FetchType.EAGER,
             mappedBy = "inventory")

--- a/src/main/java/com/amido/graphqltest/domain/MarketplaceListing.java
+++ b/src/main/java/com/amido/graphqltest/domain/MarketplaceListing.java
@@ -1,10 +1,8 @@
 package com.amido.graphqltest.domain;
 
 import lombok.Data;
-import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.*;
-import java.util.UUID;
 
 @Data
 @Entity

--- a/src/main/java/com/amido/graphqltest/domain/MarketplaceListing.java
+++ b/src/main/java/com/amido/graphqltest/domain/MarketplaceListing.java
@@ -10,12 +10,10 @@ import java.util.UUID;
 @Entity
 @Table(name = "marketplace_listings")
 public class MarketplaceListing {
-    @Id
-    @GeneratedValue(generator = "uuid2")
-    @GenericGenerator(name = "uuid2", strategy = "uuid2")
-    @Column(columnDefinition = "VARCHAR(36)")
-    private UUID id;
 
+    @Id
+    @Column(columnDefinition = "VARCHAR(36)")
+    private String id;
 
     @OneToOne
     @JoinColumn(

--- a/src/main/java/com/amido/graphqltest/domain/MarketplaceListing.java
+++ b/src/main/java/com/amido/graphqltest/domain/MarketplaceListing.java
@@ -1,0 +1,38 @@
+package com.amido.graphqltest.domain;
+
+import lombok.Data;
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Data
+@Entity
+@Table(name = "marketplace_listings")
+public class MarketplaceListing {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "VARCHAR(36)")
+    private UUID id;
+
+
+    @OneToOne
+    @JoinColumn(
+            name = "seller_id",
+            referencedColumnName = "id"
+    )
+    private Player seller;
+
+    @OneToOne
+    @JoinColumn(
+            name = "item_id",
+            referencedColumnName = "id"
+    )
+    private Item item;
+
+    @Column(name = "requested_price")
+    private int requestedPrice;
+
+    private String status;
+}

--- a/src/main/java/com/amido/graphqltest/domain/MarketplaceListing.java
+++ b/src/main/java/com/amido/graphqltest/domain/MarketplaceListing.java
@@ -1,10 +1,13 @@
 package com.amido.graphqltest.domain;
 
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.persistence.*;
 
-@Data
+@Getter
+@Setter
 @Entity
 @Table(name = "marketplace_listings")
 public class MarketplaceListing {

--- a/src/main/java/com/amido/graphqltest/domain/MarketplaceReceipt.java
+++ b/src/main/java/com/amido/graphqltest/domain/MarketplaceReceipt.java
@@ -1,0 +1,15 @@
+package com.amido.graphqltest.domain;
+
+import lombok.Data;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Data
+public class MarketplaceReceipt {
+    private UUID id;
+    private Player seller;
+    private Player buyer;
+    private MarketplaceListing listing;
+    private Date transactionDate;
+}

--- a/src/main/java/com/amido/graphqltest/domain/MarketplaceReceipt.java
+++ b/src/main/java/com/amido/graphqltest/domain/MarketplaceReceipt.java
@@ -1,15 +1,27 @@
 package com.amido.graphqltest.domain;
 
+import com.amido.graphqltest.domain.dto.ItemDto;
+import com.amido.graphqltest.domain.dto.PlayerDto;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.apache.commons.lang3.builder.ToStringExclude;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
 
 import java.util.Date;
-import java.util.UUID;
 
-@Data
+@Getter
+@Setter
+@Document(indexName = "marketplace-receipts")
 public class MarketplaceReceipt {
-    private UUID id;
-    private Player seller;
-    private Player buyer;
-    private MarketplaceListing listing;
+    @Id
+    private String id;
+    private PlayerDto seller;
+    private PlayerDto buyer;
+    private ItemDto item;
+    private int sellPrice;
     private Date transactionDate;
 }

--- a/src/main/java/com/amido/graphqltest/domain/Player.java
+++ b/src/main/java/com/amido/graphqltest/domain/Player.java
@@ -25,4 +25,5 @@ public class Player {
     )
     private List<Item> inventory = new ArrayList<>();
 
+    private int currency;
 }

--- a/src/main/java/com/amido/graphqltest/domain/Player.java
+++ b/src/main/java/com/amido/graphqltest/domain/Player.java
@@ -1,12 +1,15 @@
 package com.amido.graphqltest.domain;
 
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
-@Data
+@Getter
+@Setter
 @Entity
 @Table(name = "players")
 public class Player {

--- a/src/main/java/com/amido/graphqltest/domain/dto/ItemDto.java
+++ b/src/main/java/com/amido/graphqltest/domain/dto/ItemDto.java
@@ -1,0 +1,19 @@
+package com.amido.graphqltest.domain.dto;
+
+import com.amido.graphqltest.domain.Item;
+import lombok.Data;
+
+@Data
+public class ItemDto {
+
+    private final int id;
+    private final String name;
+    private final String effect;
+
+    public static ItemDto from(final Item item) {
+        return new ItemDto(item.getId(),
+                item.getName(),
+                item.getEffect());
+    }
+
+}

--- a/src/main/java/com/amido/graphqltest/domain/dto/PlayerDto.java
+++ b/src/main/java/com/amido/graphqltest/domain/dto/PlayerDto.java
@@ -1,0 +1,17 @@
+package com.amido.graphqltest.domain.dto;
+
+import com.amido.graphqltest.domain.Player;
+import lombok.Data;
+
+@Data
+public class PlayerDto {
+    private final int id;
+    private final String username;
+    private final int level;
+
+    public static PlayerDto from(final Player player) {
+        return new PlayerDto(player.getId(),
+                player.getUsername(),
+                player.getLevel());
+    }
+}

--- a/src/main/java/com/amido/graphqltest/exception/ItemAlreadyOwnedException.java
+++ b/src/main/java/com/amido/graphqltest/exception/ItemAlreadyOwnedException.java
@@ -1,7 +1,7 @@
 package com.amido.graphqltest.exception;
 
 public class ItemAlreadyOwnedException extends RuntimeException {
-    public ItemAlreadyOwnedException(final String message){
+    public ItemAlreadyOwnedException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/amido/graphqltest/exception/ItemAlreadyOwnedException.java
+++ b/src/main/java/com/amido/graphqltest/exception/ItemAlreadyOwnedException.java
@@ -1,0 +1,7 @@
+package com.amido.graphqltest.exception;
+
+public class ItemAlreadyOwnedException extends RuntimeException {
+    public ItemAlreadyOwnedException(final String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/amido/graphqltest/exception/ItemNotFoundException.java
+++ b/src/main/java/com/amido/graphqltest/exception/ItemNotFoundException.java
@@ -1,0 +1,7 @@
+package com.amido.graphqltest.exception;
+
+public class ItemNotFoundException extends RuntimeException {
+    public ItemNotFoundException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/amido/graphqltest/exception/ListingNotFoundException.java
+++ b/src/main/java/com/amido/graphqltest/exception/ListingNotFoundException.java
@@ -1,0 +1,7 @@
+package com.amido.graphqltest.exception;
+
+public class ListingNotFoundException extends RuntimeException {
+    public ListingNotFoundException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/amido/graphqltest/exception/NotEnoughCurrencyException.java
+++ b/src/main/java/com/amido/graphqltest/exception/NotEnoughCurrencyException.java
@@ -1,7 +1,7 @@
 package com.amido.graphqltest.exception;
 
-public class NotEnoughCurrencyException extends RuntimeException{
-    public NotEnoughCurrencyException(final String message){
+public class NotEnoughCurrencyException extends RuntimeException {
+    public NotEnoughCurrencyException(final String message) {
         super(message);
     }
 }

--- a/src/main/java/com/amido/graphqltest/exception/NotEnoughCurrencyException.java
+++ b/src/main/java/com/amido/graphqltest/exception/NotEnoughCurrencyException.java
@@ -1,0 +1,7 @@
+package com.amido.graphqltest.exception;
+
+public class NotEnoughCurrencyException extends RuntimeException{
+    public NotEnoughCurrencyException(final String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/amido/graphqltest/graphql/mutation/MarketplaceListingMutation.java
+++ b/src/main/java/com/amido/graphqltest/graphql/mutation/MarketplaceListingMutation.java
@@ -1,7 +1,9 @@
 package com.amido.graphqltest.graphql.mutation;
 
 import com.amido.graphqltest.domain.MarketplaceListing;
+import com.amido.graphqltest.domain.MarketplaceReceipt;
 import com.amido.graphqltest.service.MarketplaceListingService;
+import com.amido.graphqltest.service.MarketplacePurchaseService;
 import com.coxautodev.graphql.tools.GraphQLMutationResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,12 +13,19 @@ import org.springframework.stereotype.Component;
 public class MarketplaceListingMutation implements GraphQLMutationResolver {
 
     private final MarketplaceListingService marketplaceListingService;
+    private final MarketplacePurchaseService marketplacePurchaseService;
 
     public MarketplaceListing addMarketplaceListing(
             final Integer userId,
             final Integer itemId,
             final Integer requestedPrice) {
         return marketplaceListingService.addMarketplaceListing(userId, itemId, requestedPrice);
+    }
+
+    public MarketplaceReceipt buyItem(
+            final String listingId,
+            final Integer buyerId) {
+        return marketplacePurchaseService.buyItem(listingId, buyerId);
     }
 
 }

--- a/src/main/java/com/amido/graphqltest/graphql/mutation/MarketplaceListingMutation.java
+++ b/src/main/java/com/amido/graphqltest/graphql/mutation/MarketplaceListingMutation.java
@@ -1,0 +1,22 @@
+package com.amido.graphqltest.graphql.mutation;
+
+import com.amido.graphqltest.domain.MarketplaceListing;
+import com.amido.graphqltest.service.MarketplaceListingService;
+import com.coxautodev.graphql.tools.GraphQLMutationResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MarketplaceListingMutation implements GraphQLMutationResolver {
+
+    private final MarketplaceListingService marketplaceListingService;
+
+    public MarketplaceListing addMarketplaceListing(
+            final Integer userId,
+            final Integer itemId,
+            final Integer requestedPrice) {
+        return marketplaceListingService.addMarketplaceListing(userId, itemId, requestedPrice);
+    }
+
+}

--- a/src/main/java/com/amido/graphqltest/graphql/mutation/PlayerMutation.java
+++ b/src/main/java/com/amido/graphqltest/graphql/mutation/PlayerMutation.java
@@ -16,4 +16,8 @@ public class PlayerMutation implements GraphQLMutationResolver {
         return playerService.addNewPlayer(username);
     }
 
+    public Integer removePlayer(final String username) {
+        return playerService.removePlayerByUsername(username);
+    }
+
 }

--- a/src/main/java/com/amido/graphqltest/graphql/query/MarketplaceQuery.java
+++ b/src/main/java/com/amido/graphqltest/graphql/query/MarketplaceQuery.java
@@ -1,12 +1,17 @@
 package com.amido.graphqltest.graphql.query;
 
 import com.amido.graphqltest.domain.MarketplaceListing;
+import com.amido.graphqltest.domain.MarketplaceReceipt;
 import com.amido.graphqltest.repository.MarketplaceListingRepository;
+import com.amido.graphqltest.repository.MarketplaceReceiptRepository;
 import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Component
 @RequiredArgsConstructor
@@ -14,8 +19,16 @@ public class MarketplaceQuery implements GraphQLQueryResolver {
 
     private final MarketplaceListingRepository marketplaceListingRepository;
 
+    private final MarketplaceReceiptRepository marketplaceReceiptRepository;
+
     public List<MarketplaceListing> getAllMarketplaceListings() {
         return marketplaceListingRepository.findAll();
+    }
+
+    public List<MarketplaceReceipt> getAllMarketplaceReceipts() {
+        final List<MarketplaceReceipt> receipts = new ArrayList<>();
+        marketplaceReceiptRepository.findAll().forEach(receipts::add);
+        return receipts;
     }
 
 }

--- a/src/main/java/com/amido/graphqltest/graphql/query/MarketplaceQuery.java
+++ b/src/main/java/com/amido/graphqltest/graphql/query/MarketplaceQuery.java
@@ -1,0 +1,21 @@
+package com.amido.graphqltest.graphql.query;
+
+import com.amido.graphqltest.domain.MarketplaceListing;
+import com.amido.graphqltest.repository.MarketplaceListingRepository;
+import com.coxautodev.graphql.tools.GraphQLQueryResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class MarketplaceQuery implements GraphQLQueryResolver {
+
+    private final MarketplaceListingRepository marketplaceListingRepository;
+
+    public List<MarketplaceListing> getAllMarketplaceListings() {
+        return marketplaceListingRepository.findAll();
+    }
+
+}

--- a/src/main/java/com/amido/graphqltest/properties/ElasticsearchProperties.java
+++ b/src/main/java/com/amido/graphqltest/properties/ElasticsearchProperties.java
@@ -1,0 +1,11 @@
+package com.amido.graphqltest.properties;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "app.elasticsearch")
+public class ElasticsearchProperties {
+    private String host;
+    private String port;
+}

--- a/src/main/java/com/amido/graphqltest/repository/MarketplaceListingRepository.java
+++ b/src/main/java/com/amido/graphqltest/repository/MarketplaceListingRepository.java
@@ -1,0 +1,11 @@
+package com.amido.graphqltest.repository;
+
+import com.amido.graphqltest.domain.MarketplaceListing;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface MarketplaceListingRepository extends JpaRepository<MarketplaceListing, UUID> {
+}

--- a/src/main/java/com/amido/graphqltest/repository/MarketplaceListingRepository.java
+++ b/src/main/java/com/amido/graphqltest/repository/MarketplaceListingRepository.java
@@ -4,8 +4,6 @@ import com.amido.graphqltest.domain.MarketplaceListing;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.UUID;
-
 @Repository
 public interface MarketplaceListingRepository extends JpaRepository<MarketplaceListing, String> {
 }

--- a/src/main/java/com/amido/graphqltest/repository/MarketplaceListingRepository.java
+++ b/src/main/java/com/amido/graphqltest/repository/MarketplaceListingRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
-public interface MarketplaceListingRepository extends JpaRepository<MarketplaceListing, UUID> {
+public interface MarketplaceListingRepository extends JpaRepository<MarketplaceListing, String> {
 }

--- a/src/main/java/com/amido/graphqltest/repository/MarketplaceReceiptRepository.java
+++ b/src/main/java/com/amido/graphqltest/repository/MarketplaceReceiptRepository.java
@@ -1,0 +1,11 @@
+package com.amido.graphqltest.repository;
+
+import com.amido.graphqltest.domain.MarketplaceReceipt;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface MarketplaceReceiptRepository extends ElasticsearchRepository<MarketplaceReceipt, String> {
+}

--- a/src/main/java/com/amido/graphqltest/service/MarketplaceListingService.java
+++ b/src/main/java/com/amido/graphqltest/service/MarketplaceListingService.java
@@ -1,0 +1,11 @@
+package com.amido.graphqltest.service;
+
+import com.amido.graphqltest.domain.MarketplaceListing;
+
+public interface MarketplaceListingService {
+
+    MarketplaceListing addMarketplaceListing(int playerId,
+                                             int itemId,
+                                             int price);
+
+}

--- a/src/main/java/com/amido/graphqltest/service/MarketplaceListingService.java
+++ b/src/main/java/com/amido/graphqltest/service/MarketplaceListingService.java
@@ -1,7 +1,6 @@
 package com.amido.graphqltest.service;
 
 import com.amido.graphqltest.domain.MarketplaceListing;
-import com.amido.graphqltest.domain.MarketplaceReceipt;
 
 public interface MarketplaceListingService {
 

--- a/src/main/java/com/amido/graphqltest/service/MarketplaceListingService.java
+++ b/src/main/java/com/amido/graphqltest/service/MarketplaceListingService.java
@@ -1,11 +1,14 @@
 package com.amido.graphqltest.service;
 
 import com.amido.graphqltest.domain.MarketplaceListing;
+import com.amido.graphqltest.domain.MarketplaceReceipt;
 
 public interface MarketplaceListingService {
 
     MarketplaceListing addMarketplaceListing(int playerId,
                                              int itemId,
                                              int price);
+
+    MarketplaceListing findMarketplaceListingById(String id);
 
 }

--- a/src/main/java/com/amido/graphqltest/service/MarketplaceListingService.java
+++ b/src/main/java/com/amido/graphqltest/service/MarketplaceListingService.java
@@ -11,4 +11,6 @@ public interface MarketplaceListingService {
 
     MarketplaceListing findMarketplaceListingById(String id);
 
+    void deleteMarketplaceListingById(String id);
+
 }

--- a/src/main/java/com/amido/graphqltest/service/MarketplaceListingServiceImpl.java
+++ b/src/main/java/com/amido/graphqltest/service/MarketplaceListingServiceImpl.java
@@ -1,0 +1,56 @@
+package com.amido.graphqltest.service;
+
+import com.amido.graphqltest.domain.Item;
+import com.amido.graphqltest.domain.MarketplaceListing;
+import com.amido.graphqltest.domain.Player;
+import com.amido.graphqltest.exception.ItemNotFoundException;
+import com.amido.graphqltest.repository.MarketplaceListingRepository;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+@Service
+@RequiredArgsConstructor
+public class MarketplaceListingServiceImpl implements MarketplaceListingService {
+
+    private final Supplier<UUID> uuidSupplier;
+    private final PlayerService playerService;
+    private final MarketplaceListingRepository marketplaceListingRepository;
+
+    @Override
+    public MarketplaceListing addMarketplaceListing(
+            final int playerId,
+            final int itemId,
+            final int price) {
+        final Player seller = playerService.findPlayerById(playerId);
+        final Item item = seller.getInventory().stream()
+                .filter(i -> i.getId() == itemId)
+                .findFirst()
+                .orElseThrow(() -> new ItemNotFoundException(
+                        String.format("Player %s does not have item with ID: %d",
+                                seller.getUsername(),
+                                itemId)));
+        seller.getInventory().remove(item);
+        playerService.updatePlayer(seller);
+        return marketplaceListingRepository.save(toListing(price, seller).apply(item));
+    }
+
+    @NotNull
+    private Function<Item, MarketplaceListing> toListing(
+            final int price,
+            final Player seller) {
+        return item -> {
+            final MarketplaceListing listing = new MarketplaceListing();
+            listing.setId(uuidSupplier.get().toString());
+            listing.setItem(item);
+            listing.setSeller(seller);
+            listing.setStatus("For Sale");
+            listing.setRequestedPrice(price);
+            return listing;
+        };
+    }
+}

--- a/src/main/java/com/amido/graphqltest/service/MarketplaceListingServiceImpl.java
+++ b/src/main/java/com/amido/graphqltest/service/MarketplaceListingServiceImpl.java
@@ -46,6 +46,12 @@ public class MarketplaceListingServiceImpl implements MarketplaceListingService 
                 .orElseThrow(() -> new ListingNotFoundException("Listing with ID: " + id + " not found on marketplace."));
     }
 
+    @Override
+    public void deleteMarketplaceListingById(final String id) {
+       final MarketplaceListing listingToBeDeleted = findMarketplaceListingById(id);
+       marketplaceListingRepository.delete(listingToBeDeleted);
+    }
+
     @NotNull
     private Function<Item, MarketplaceListing> toListing(
             final int price,

--- a/src/main/java/com/amido/graphqltest/service/MarketplaceListingServiceImpl.java
+++ b/src/main/java/com/amido/graphqltest/service/MarketplaceListingServiceImpl.java
@@ -4,6 +4,7 @@ import com.amido.graphqltest.domain.Item;
 import com.amido.graphqltest.domain.MarketplaceListing;
 import com.amido.graphqltest.domain.Player;
 import com.amido.graphqltest.exception.ItemNotFoundException;
+import com.amido.graphqltest.exception.ListingNotFoundException;
 import com.amido.graphqltest.repository.MarketplaceListingRepository;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
@@ -37,6 +38,12 @@ public class MarketplaceListingServiceImpl implements MarketplaceListingService 
         seller.getInventory().remove(item);
         playerService.updatePlayer(seller);
         return marketplaceListingRepository.save(toListing(price, seller).apply(item));
+    }
+
+    @Override
+    public MarketplaceListing findMarketplaceListingById(final String id) {
+        return marketplaceListingRepository.findById(id)
+                .orElseThrow(() -> new ListingNotFoundException("Listing with ID: " + id + " not found on marketplace."));
     }
 
     @NotNull

--- a/src/main/java/com/amido/graphqltest/service/MarketplaceListingServiceImpl.java
+++ b/src/main/java/com/amido/graphqltest/service/MarketplaceListingServiceImpl.java
@@ -48,8 +48,8 @@ public class MarketplaceListingServiceImpl implements MarketplaceListingService 
 
     @Override
     public void deleteMarketplaceListingById(final String id) {
-       final MarketplaceListing listingToBeDeleted = findMarketplaceListingById(id);
-       marketplaceListingRepository.delete(listingToBeDeleted);
+        final MarketplaceListing listingToBeDeleted = findMarketplaceListingById(id);
+        marketplaceListingRepository.delete(listingToBeDeleted);
     }
 
     @NotNull

--- a/src/main/java/com/amido/graphqltest/service/MarketplacePurchaseService.java
+++ b/src/main/java/com/amido/graphqltest/service/MarketplacePurchaseService.java
@@ -1,0 +1,10 @@
+package com.amido.graphqltest.service;
+
+import com.amido.graphqltest.domain.MarketplaceReceipt;
+
+public interface MarketplacePurchaseService {
+
+    MarketplaceReceipt buyItem(String listingId,
+                               int playerId);
+
+}

--- a/src/main/java/com/amido/graphqltest/service/MarketplacePurchaseServiceImpl.java
+++ b/src/main/java/com/amido/graphqltest/service/MarketplacePurchaseServiceImpl.java
@@ -33,6 +33,7 @@ public class MarketplacePurchaseServiceImpl implements MarketplacePurchaseServic
         final Player updatedBuyer = updateBuyer(buyer, buyerBalanceAfterPurchase, listing.getItem());
         final Player seller = listing.getSeller();
         final Player updatedSeller = updateSeller(seller, listing.getRequestedPrice());
+        marketplaceListingService.deleteMarketplaceListingById(listingId);
         return createReceipt(listing, updatedBuyer, updatedSeller);
     }
 

--- a/src/main/java/com/amido/graphqltest/service/MarketplacePurchaseServiceImpl.java
+++ b/src/main/java/com/amido/graphqltest/service/MarketplacePurchaseServiceImpl.java
@@ -1,0 +1,86 @@
+package com.amido.graphqltest.service;
+
+import com.amido.graphqltest.domain.Item;
+import com.amido.graphqltest.domain.MarketplaceListing;
+import com.amido.graphqltest.domain.MarketplaceReceipt;
+import com.amido.graphqltest.domain.Player;
+import com.amido.graphqltest.exception.ItemAlreadyOwnedException;
+import com.amido.graphqltest.exception.NotEnoughCurrencyException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.sql.Date;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class MarketplacePurchaseServiceImpl implements MarketplacePurchaseService {
+
+    private final Clock clock;
+    private final PlayerService playerService;
+    private final MarketplaceListingService marketplaceListingService;
+
+    @Override
+    public MarketplaceReceipt buyItem(
+            final String listingId,
+            final int buyerId) {
+        final MarketplaceListing listing = marketplaceListingService.findMarketplaceListingById(listingId);
+        final Player buyer = playerService.findPlayerById(buyerId);
+        checkBuyerDoesNotOwnItem(buyer, listing.getItem());
+        final int buyerBalanceAfterPurchase = getBalanceAfterPurchase(buyer, listing.getRequestedPrice());
+        final Player updatedBuyer = updateBuyer(buyer, buyerBalanceAfterPurchase, listing.getItem());
+        final Player seller = listing.getSeller();
+        final Player updatedSeller = updateSeller(seller, listing.getRequestedPrice());
+        return createReceipt(listing, updatedBuyer, updatedSeller);
+    }
+
+    private void checkBuyerDoesNotOwnItem(final Player buyer, final Item item) {
+        final boolean buyerOwnsItem = buyer.getInventory().stream()
+                .anyMatch(i -> i.equals(item));
+        if (buyerOwnsItem) {
+            throw new ItemAlreadyOwnedException("You already own this item and cannot buy another");
+        }
+    }
+
+    private int getBalanceAfterPurchase(
+            final Player buyer,
+            final int requestedPrice) {
+        final int balanceAfterPurchase = buyer.getCurrency() - requestedPrice;
+        if (balanceAfterPurchase < 0) {
+            throw new NotEnoughCurrencyException("Insufficient balance to purchase listing");
+        }
+        return balanceAfterPurchase;
+    }
+
+    private Player updateBuyer(
+            final Player buyer,
+            final int balanceAfterPurchase,
+            final Item purchasedItem) {
+        buyer.setCurrency(balanceAfterPurchase);
+        buyer.getInventory().add(purchasedItem);
+        return playerService.updatePlayer(buyer);
+    }
+
+    private Player updateSeller(
+            final Player seller,
+            final int listingPrice) {
+        seller.setCurrency(seller.getCurrency() + listingPrice);
+        return playerService.updatePlayer(seller);
+    }
+
+    private MarketplaceReceipt createReceipt(
+            final MarketplaceListing listing,
+            final Player buyer,
+            final Player seller) {
+        MarketplaceReceipt marketplaceReceipt = new MarketplaceReceipt();
+        marketplaceReceipt.setId(UUID.randomUUID());
+        marketplaceReceipt.setBuyer(buyer);
+        marketplaceReceipt.setSeller(seller);
+        marketplaceReceipt.setListing(listing);
+        final Instant now = Instant.now(clock);
+        marketplaceReceipt.setTransactionDate(Date.from(now));
+        return marketplaceReceipt;
+    }
+}

--- a/src/main/java/com/amido/graphqltest/service/PlayerService.java
+++ b/src/main/java/com/amido/graphqltest/service/PlayerService.java
@@ -14,4 +14,6 @@ public interface PlayerService {
 
     Integer removePlayerByUsername(String username);
 
+    Player updatePlayer(Player player);
+
 }

--- a/src/main/java/com/amido/graphqltest/service/PlayerService.java
+++ b/src/main/java/com/amido/graphqltest/service/PlayerService.java
@@ -12,4 +12,6 @@ public interface PlayerService {
 
     Player findPlayerById(Integer id);
 
+    Integer removePlayerByUsername(String username);
+
 }

--- a/src/main/java/com/amido/graphqltest/service/PlayerServiceImpl.java
+++ b/src/main/java/com/amido/graphqltest/service/PlayerServiceImpl.java
@@ -35,4 +35,15 @@ public class PlayerServiceImpl implements PlayerService {
         return playerRepository.findById(id)
                 .orElseThrow(() -> new PlayerNotFoundException("Player with id " + id + " not found"));
     }
+
+    @Override
+    public Integer removePlayerByUsername(String username) {
+        return playerRepository.findByUsername(username)
+                .map(p -> {
+                    int id = p.getId();
+                    playerRepository.delete(p);
+                    return id;
+                })
+                .orElseThrow(() -> new PlayerNotFoundException("Player with username " + username + " not found"));
+    }
 }

--- a/src/main/java/com/amido/graphqltest/service/PlayerServiceImpl.java
+++ b/src/main/java/com/amido/graphqltest/service/PlayerServiceImpl.java
@@ -46,4 +46,9 @@ public class PlayerServiceImpl implements PlayerService {
                 })
                 .orElseThrow(() -> new PlayerNotFoundException("Player with username " + username + " not found"));
     }
+
+    @Override
+    public Player updatePlayer(final Player player) {
+        return playerRepository.save(player);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,8 @@ spring:
     hibernate:
       ddl-auto: ${DDL_AUTO_TYPE:validate}
 
+app:
+  elasticsearch:
+    host: ${ELASTIC_SEARCH_HOST:localhost}
+    port: ${ELASTIC_SEARCH_PORT:9200}
+

--- a/src/main/resources/db/migration/V1__base-database.sql
+++ b/src/main/resources/db/migration/V1__base-database.sql
@@ -36,7 +36,7 @@ VALUES ('whiterose', 42),
 insert into items (name, effect)
 VALUES ('Red Potion of Healing', 'Restore 50HP'),
        ('Blue Potion of Mana', 'Restore 20MP'),
-       ('Green Potion of Magic', 'Restore 50HGP');
+       ('Green Potion of Magic', 'Restore 50MGP');
 
 insert into player_items (player_id, item_id)
 values (2, 1),

--- a/src/main/resources/db/migration/V2__add-marketplace-listings-table.sql
+++ b/src/main/resources/db/migration/V2__add-marketplace-listings-table.sql
@@ -1,0 +1,21 @@
+-- Create table for marketplace listings
+CREATE TABLE marketplace_listings
+(
+    id              VARCHAR(36) PRIMARY KEY,
+    seller_id       int          NOT NULL,
+    item_id         int          NOT NULL,
+    requested_price int          NOT NULL,
+    status          varchar(255) NOT NULL,
+
+    constraint fk_market_place_seller_id
+        foreign key (seller_id)
+            references players (id),
+    constraint fk_market_place_item_id
+        foreign key (item_id)
+            references items (id)
+);
+
+-- Add seed data for marketplace listings
+INSERT INTO marketplace_listings (id, seller_id, item_id, requested_price, status)
+VALUES ('d3283bea-dc18-486f-aa8a-60455b566d47', 1, 2, 200, 'For Sale'),
+       ('f0765e7a-d7a9-43fb-9ffc-39a97061e518', 1, 2, 100, 'For Sale');

--- a/src/main/resources/db/migration/V3__add-currency-to-player.sql
+++ b/src/main/resources/db/migration/V3__add-currency-to-player.sql
@@ -1,0 +1,4 @@
+ALTER TABLE graphql_test.players
+    ADD COLUMN (
+        currency int NOT NULL
+        );

--- a/src/main/resources/graphql/marketplace-schema.graphqls
+++ b/src/main/resources/graphql/marketplace-schema.graphqls
@@ -10,8 +10,9 @@ type MarketplaceListing {
 # Type defining a receipt for an item purchase between two players for an agreed price
 type MarketplaceReceipt {
     id: ID!
-    seller: Player
-    buyer: Player
-    listing: MarketplaceListing
+    seller: PlayerDto
+    buyer: PlayerDto
+    item: ItemDto
+    sellPrice: Int
     transactionDate: String
 }

--- a/src/main/resources/graphql/marketplace-schema.graphqls
+++ b/src/main/resources/graphql/marketplace-schema.graphqls
@@ -1,0 +1,17 @@
+# Type defining an item that is currently for sale on the marketplace.
+type MarketplaceListing {
+    id: ID!
+    seller: Player!
+    item: Item!
+    requestedPrice: Int!
+    status: String
+}
+
+# Type defining a receipt for an item purchase between two players for an agreed price
+type MarketplaceReceipt {
+    id: ID!
+    seller: Player
+    buyer: Player
+    listing: MarketplaceListing
+    transactionDate: String
+}

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -20,5 +20,5 @@ type Query {
 type Mutation {
     addNewPlayer(username: String!) : Player!
     removePlayer(username: String) : Int!
-    # TODO: Implement addMarketplaceListing(userId: ID!, itemId: ID!, requestedPrice: Int) : MarketplaceListing!
+    addMarketplaceListing(userId: ID!, itemId: ID!, requestedPrice: Int) : MarketplaceListing!
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -22,4 +22,5 @@ type Mutation {
     addNewPlayer(username: String!) : Player!
     removePlayer(username: String) : Int!
     addMarketplaceListing(userId: ID!, itemId: ID!, requestedPrice: Int) : MarketplaceListing!
+    buyItem(listingId: ID!, buyerId: ID! ) : MarketplaceReceipt!
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -6,7 +6,19 @@ type Player {
     currency: Int
 }
 
+type PlayerDto {
+    id: ID!
+    username: String!
+    level: Int
+}
+
 type Item {
+    id: ID!
+    name: String!
+    effect: String!
+}
+
+type ItemDto {
     id: ID!
     name: String!
     effect: String!
@@ -16,6 +28,7 @@ type Query {
     allPlayers: [Player]!
     allPlayerItems(userId: ID!): [Item]!
     allMarketplaceListings: [MarketplaceListing]!
+    allMarketplaceReceipts: [MarketplaceReceipt]!
 }
 
 type Mutation {

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -14,8 +14,11 @@ type Item {
 type Query {
     allPlayers: [Player]!
     allPlayerItems(userId: ID!): [Item]!
+    allMarketplaceListings: [MarketplaceListing]!
 }
 
 type Mutation {
     addNewPlayer(username: String!) : Player!
+    removePlayer(username: String) : Int!
+    # TODO: Implement addMarketplaceListing(userId: ID!, itemId: ID!, requestedPrice: Int) : MarketplaceListing!
 }

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -3,6 +3,7 @@ type Player {
     username: String!
     level: Int
     inventory: [Item]!
+    currency: Int
 }
 
 type Item {

--- a/src/test/java/com/amido/graphqltest/domain/dto/ItemDtoTest.java
+++ b/src/test/java/com/amido/graphqltest/domain/dto/ItemDtoTest.java
@@ -1,0 +1,28 @@
+package com.amido.graphqltest.domain.dto;
+
+import com.amido.graphqltest.domain.Item;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class ItemDtoTest {
+
+    @Test
+    public void canConvertFromDomainItem() {
+        final Item item = new Item();
+        item.setId(1);
+        item.setName("Potion");
+        item.setEffect("Restore 10HP");
+
+        assertThat(ItemDto.from(item))
+                .satisfies(dto -> {
+                    assertThat(dto.getId())
+                            .isEqualTo(1);
+                    assertThat(dto.getName())
+                            .isEqualTo("Potion");
+                    assertThat(dto.getEffect())
+                            .isEqualTo("Restore 10HP");
+                });
+    }
+
+}

--- a/src/test/java/com/amido/graphqltest/domain/dto/PlayerDtoTest.java
+++ b/src/test/java/com/amido/graphqltest/domain/dto/PlayerDtoTest.java
@@ -1,0 +1,28 @@
+package com.amido.graphqltest.domain.dto;
+
+import com.amido.graphqltest.domain.Player;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class PlayerDtoTest {
+
+    @Test
+    public void canConvertFromDomainPlayer() {
+        final Player player = new Player();
+        player.setId(1);
+        player.setUsername("player");
+        player.setLevel(10);
+
+        assertThat(PlayerDto.from(player))
+                .satisfies(dto -> {
+                    assertThat(dto.getId())
+                            .isEqualTo(1);
+                    assertThat(dto.getUsername())
+                            .isEqualTo("player");
+                    assertThat(dto.getLevel())
+                            .isEqualTo(10);
+                });
+    }
+
+}

--- a/src/test/java/com/amido/graphqltest/graphql/mutation/PlayerMutationIT.java
+++ b/src/test/java/com/amido/graphqltest/graphql/mutation/PlayerMutationIT.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.annotation.DirtiesContext;
 
 import java.io.IOException;
 

--- a/src/test/java/com/amido/graphqltest/graphql/mutation/PlayerMutationIT.java
+++ b/src/test/java/com/amido/graphqltest/graphql/mutation/PlayerMutationIT.java
@@ -4,9 +4,12 @@ import com.amido.graphqltest.GraphqlTestApplication;
 import com.amido.graphqltest.configuration.GraphQlIntegrationTestBase;
 import com.graphql.spring.boot.test.GraphQLResponse;
 import org.json.JSONException;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.io.IOException;
 
@@ -17,7 +20,13 @@ import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
         webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
         classes = GraphqlTestApplication.class
 )
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PlayerMutationIT extends GraphQlIntegrationTestBase {
+
+    @AfterAll
+    void cleanUp() throws IOException {
+        graphQLTestTemplate.postForResource(String.format(GRAPHQL_REQUEST_RESOURCE, MUTATION, "removePlayer"));
+    }
 
     @Test
     public void givenAPlayerShouldBeAdded_WhenAddingPlayer_ThenJsonContainingTheCreatedPlayerIsReturned() throws IOException, JSONException {

--- a/src/test/java/com/amido/graphqltest/graphql/query/MarketplaceQueryTest.java
+++ b/src/test/java/com/amido/graphqltest/graphql/query/MarketplaceQueryTest.java
@@ -3,11 +3,9 @@ package com.amido.graphqltest.graphql.query;
 import com.amido.graphqltest.domain.MarketplaceListing;
 import com.amido.graphqltest.repository.MarketplaceListingRepository;
 import org.junit.jupiter.api.Test;
-import org.yaml.snakeyaml.error.Mark;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 
@@ -17,7 +15,7 @@ public class MarketplaceQueryTest {
     private final MarketplaceQuery marketplaceQuery = new MarketplaceQuery(marketplaceListingRepository);
 
     @Test
-    public void givenAllMarketListingsAreRequested_WhenSearchingForMarketListings_ThenThisActionIsPerformedUsingTheMarketListingRepository(){
+    public void givenAllMarketListingsAreRequested_WhenSearchingForMarketListings_ThenThisActionIsPerformedUsingTheMarketListingRepository() {
         final List<MarketplaceListing> allMarketplaceListings = marketplaceQuery.getAllMarketplaceListings();
 
         then(marketplaceListingRepository)

--- a/src/test/java/com/amido/graphqltest/graphql/query/MarketplaceQueryTest.java
+++ b/src/test/java/com/amido/graphqltest/graphql/query/MarketplaceQueryTest.java
@@ -1,0 +1,28 @@
+package com.amido.graphqltest.graphql.query;
+
+import com.amido.graphqltest.domain.MarketplaceListing;
+import com.amido.graphqltest.repository.MarketplaceListingRepository;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.error.Mark;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+public class MarketplaceQueryTest {
+
+    private final MarketplaceListingRepository marketplaceListingRepository = mock(MarketplaceListingRepository.class);
+    private final MarketplaceQuery marketplaceQuery = new MarketplaceQuery(marketplaceListingRepository);
+
+    @Test
+    public void givenAllMarketListingsAreRequested_WhenSearchingForMarketListings_ThenThisActionIsPerformedUsingTheMarketListingRepository(){
+        final List<MarketplaceListing> allMarketplaceListings = marketplaceQuery.getAllMarketplaceListings();
+
+        then(marketplaceListingRepository)
+                .should()
+                .findAll();
+    }
+
+}

--- a/src/test/java/com/amido/graphqltest/graphql/query/MarketplaceQueryTest.java
+++ b/src/test/java/com/amido/graphqltest/graphql/query/MarketplaceQueryTest.java
@@ -2,6 +2,7 @@ package com.amido.graphqltest.graphql.query;
 
 import com.amido.graphqltest.domain.MarketplaceListing;
 import com.amido.graphqltest.repository.MarketplaceListingRepository;
+import com.amido.graphqltest.repository.MarketplaceReceiptRepository;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -12,7 +13,10 @@ import static org.mockito.Mockito.mock;
 public class MarketplaceQueryTest {
 
     private final MarketplaceListingRepository marketplaceListingRepository = mock(MarketplaceListingRepository.class);
-    private final MarketplaceQuery marketplaceQuery = new MarketplaceQuery(marketplaceListingRepository);
+    private final MarketplaceReceiptRepository marketplaceReceiptRepository = mock(MarketplaceReceiptRepository.class);
+    private final MarketplaceQuery marketplaceQuery = new MarketplaceQuery(
+            marketplaceListingRepository,
+            marketplaceReceiptRepository);
 
     @Test
     public void givenAllMarketListingsAreRequested_WhenSearchingForMarketListings_ThenThisActionIsPerformedUsingTheMarketListingRepository() {

--- a/src/test/java/com/amido/graphqltest/graphql/query/PlayerQueryIT.java
+++ b/src/test/java/com/amido/graphqltest/graphql/query/PlayerQueryIT.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
 
 import java.io.IOException;
 
@@ -21,7 +22,6 @@ import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 class PlayerQueryIT extends GraphQlIntegrationTestBase {
 
     @Test
-    @Disabled("Shared context between PlayerMutationIT and this test causes this test to fail unless run in isolation")
     public void givenAllPlayersAreRequested_WhenGraphQlQueryIsMade_ThenJsonContainingThreePlayersIsReturned() throws IOException, JSONException {
         final GraphQLResponse result = graphQLTestTemplate.postForResource(String.format(GRAPHQL_REQUEST_RESOURCE, QUERY, "allPlayers"));
 

--- a/src/test/java/com/amido/graphqltest/graphql/query/PlayerQueryIT.java
+++ b/src/test/java/com/amido/graphqltest/graphql/query/PlayerQueryIT.java
@@ -4,11 +4,9 @@ import com.amido.graphqltest.GraphqlTestApplication;
 import com.amido.graphqltest.configuration.GraphQlIntegrationTestBase;
 import com.graphql.spring.boot.test.GraphQLResponse;
 import org.json.JSONException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.annotation.DirtiesContext;
 
 import java.io.IOException;
 

--- a/src/test/java/com/amido/graphqltest/service/MarketplaceListingServiceImplTest.java
+++ b/src/test/java/com/amido/graphqltest/service/MarketplaceListingServiceImplTest.java
@@ -4,11 +4,13 @@ import com.amido.graphqltest.domain.Item;
 import com.amido.graphqltest.domain.MarketplaceListing;
 import com.amido.graphqltest.domain.Player;
 import com.amido.graphqltest.exception.ItemNotFoundException;
+import com.amido.graphqltest.exception.ListingNotFoundException;
 import com.amido.graphqltest.exception.PlayerNotFoundException;
 import com.amido.graphqltest.repository.MarketplaceListingRepository;
 import com.amido.graphqltest.util.DomainExampleHelper;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -82,5 +84,31 @@ class MarketplaceListingServiceImplTest {
         then(marketplaceListingRepository)
                 .should(never())
                 .save(any());
+    }
+
+    @Test
+    public void givenMarketplaceListingDoesNotExist_WhenDeletingListing_ThenRepositoryShouldDeleteNothing() {
+        given(marketplaceListingRepository.findById("aaaaa"))
+                .willThrow(new ListingNotFoundException("Listing with ID: aaaaa not found on marketplace."));
+
+        assertThatCode(() -> marketplaceListingService.deleteMarketplaceListingById("aaaaa"))
+                .isInstanceOf(ListingNotFoundException.class);
+
+        then(marketplaceListingRepository)
+                .should(never())
+                .delete(any());
+    }
+
+    @Test
+    public void givenMarketplaceListingExists_WhenDeletingListing_ThenRepositoryShouldDeleteTheListing() {
+        final MarketplaceListing listing = new MarketplaceListing();
+        given(marketplaceListingRepository.findById("aaaaa"))
+                .willReturn(Optional.of(listing));
+
+        marketplaceListingService.deleteMarketplaceListingById("aaaaa");
+
+        then(marketplaceListingRepository)
+                .should()
+                .delete(listing);
     }
 }

--- a/src/test/java/com/amido/graphqltest/service/MarketplaceListingServiceImplTest.java
+++ b/src/test/java/com/amido/graphqltest/service/MarketplaceListingServiceImplTest.java
@@ -17,6 +17,7 @@ import static com.amido.graphqltest.util.DomainExampleHelper.redPotion;
 import static com.amido.graphqltest.util.DomainExampleHelper.testPlayer;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
@@ -52,7 +53,7 @@ class MarketplaceListingServiceImplTest {
 
         then(marketplaceListingRepository)
                 .should()
-                .save(expectedListing);
+                .save(refEq(expectedListing));
     }
 
     @Test

--- a/src/test/java/com/amido/graphqltest/service/MarketplaceListingServiceImplTest.java
+++ b/src/test/java/com/amido/graphqltest/service/MarketplaceListingServiceImplTest.java
@@ -1,0 +1,86 @@
+package com.amido.graphqltest.service;
+
+import com.amido.graphqltest.domain.Item;
+import com.amido.graphqltest.domain.MarketplaceListing;
+import com.amido.graphqltest.domain.Player;
+import com.amido.graphqltest.exception.ItemNotFoundException;
+import com.amido.graphqltest.exception.PlayerNotFoundException;
+import com.amido.graphqltest.repository.MarketplaceListingRepository;
+import com.amido.graphqltest.util.DomainExampleHelper;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import static com.amido.graphqltest.util.DomainExampleHelper.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+class MarketplaceListingServiceImplTest {
+
+    private final Supplier<UUID> uuidSupplier = mock(Supplier.class);
+    final PlayerService playerService = mock(PlayerServiceImpl.class);
+    final MarketplaceListingRepository marketplaceListingRepository = mock(MarketplaceListingRepository.class);
+    final MarketplaceListingService marketplaceListingService = new MarketplaceListingServiceImpl(
+            uuidSupplier,
+            playerService,
+            marketplaceListingRepository);
+
+    @Test
+    public void givenPlayerHasItemInInventory_WhenPlayerRequestsItemToBeListedOnMarketplace_ThenANewMarketplaceListingIsSaved() {
+        final UUID id = UUID.randomUUID();
+        final Item itemToSell = redPotion();
+        final Player seller = testPlayer(itemToSell);
+        given(playerService.findPlayerById(1))
+                .willReturn(seller);
+        given(uuidSupplier.get()).willReturn(id);
+
+        MarketplaceListing expectedListing = new MarketplaceListing();
+        expectedListing.setId(id.toString());
+        expectedListing.setItem(itemToSell);
+        expectedListing.setRequestedPrice(200);
+        expectedListing.setSeller(seller);
+        expectedListing.setStatus("For Sale");
+
+        final MarketplaceListing result = marketplaceListingService.addMarketplaceListing(1, 1, 200);
+
+        then(marketplaceListingRepository)
+                .should()
+                .save(expectedListing);
+    }
+
+    @Test
+    public void givenPlayerDoesNotHaveItemInInventory_WhenListingItemOnMarketplace_ThenListingShouldNotBeSaved(){
+        final Player seller = testPlayer();
+
+        given(playerService.findPlayerById(1))
+                .willReturn(seller);
+
+        assertThatCode(() -> marketplaceListingService.addMarketplaceListing(1, 1, 200))
+                .isInstanceOf(ItemNotFoundException.class)
+                .hasMessage("Player coolguy42 does not have item with ID: 1");
+
+        then(marketplaceListingRepository)
+                .should(never())
+                .save(any());
+    }
+
+    @Test
+    public void givenPlayerNotFoundById_WhenCreatingMarketplaceListing_ThenMarketplaceListingWillNotBeCreated(){
+        given(playerService.findPlayerById(1))
+                .willThrow(new PlayerNotFoundException("Player with id 1 not found"));
+
+        assertThatCode(() -> marketplaceListingService.addMarketplaceListing(1, 1, 200))
+                .isInstanceOf(PlayerNotFoundException.class)
+                .hasMessage("Player with id 1 not found");
+
+        then(marketplaceListingRepository)
+                .should(never())
+                .save(any());
+    }
+}

--- a/src/test/java/com/amido/graphqltest/service/MarketplaceListingServiceImplTest.java
+++ b/src/test/java/com/amido/graphqltest/service/MarketplaceListingServiceImplTest.java
@@ -7,15 +7,14 @@ import com.amido.graphqltest.exception.ItemNotFoundException;
 import com.amido.graphqltest.exception.ListingNotFoundException;
 import com.amido.graphqltest.exception.PlayerNotFoundException;
 import com.amido.graphqltest.repository.MarketplaceListingRepository;
-import com.amido.graphqltest.util.DomainExampleHelper;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 
-import static com.amido.graphqltest.util.DomainExampleHelper.*;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static com.amido.graphqltest.util.DomainExampleHelper.redPotion;
+import static com.amido.graphqltest.util.DomainExampleHelper.testPlayer;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -57,7 +56,7 @@ class MarketplaceListingServiceImplTest {
     }
 
     @Test
-    public void givenPlayerDoesNotHaveItemInInventory_WhenListingItemOnMarketplace_ThenListingShouldNotBeSaved(){
+    public void givenPlayerDoesNotHaveItemInInventory_WhenListingItemOnMarketplace_ThenListingShouldNotBeSaved() {
         final Player seller = testPlayer();
 
         given(playerService.findPlayerById(1))
@@ -73,7 +72,7 @@ class MarketplaceListingServiceImplTest {
     }
 
     @Test
-    public void givenPlayerNotFoundById_WhenCreatingMarketplaceListing_ThenMarketplaceListingWillNotBeCreated(){
+    public void givenPlayerNotFoundById_WhenCreatingMarketplaceListing_ThenMarketplaceListingWillNotBeCreated() {
         given(playerService.findPlayerById(1))
                 .willThrow(new PlayerNotFoundException("Player with id 1 not found"));
 

--- a/src/test/java/com/amido/graphqltest/service/MarketplacePurchaseServiceImplTest.java
+++ b/src/test/java/com/amido/graphqltest/service/MarketplacePurchaseServiceImplTest.java
@@ -148,6 +148,28 @@ class MarketplacePurchaseServiceImplTest {
                 .isEqualTo(200);
     }
 
+    @Test
+    public void givenPurchaseIsSuccessful_WhenPurchasingItem_ThenListingShouldBeDeletedFromMarketplace() {
+        final int buyerId = 2;
+        final Player buyer = buyer(200);
+        final MarketplaceListing listing = testMarketplaceListingForRedPotion(LISTING_ID);
+        final Player seller = listing.getSeller();
+        given(marketplaceListingService.findMarketplaceListingById(LISTING_ID))
+                .willReturn(listing);
+        given(playerService.findPlayerById(buyerId))
+                .willReturn(buyer);
+        given(playerService.updatePlayer(seller))
+                .willReturn(testPlayerWithCurrency(200));
+        given(playerService.updatePlayer(buyer))
+                .willReturn(buyer(0, redPotion()));
+
+        final MarketplaceReceipt result = marketplacePurchaseService.buyItem(LISTING_ID, buyerId);
+
+        then(marketplaceListingService)
+                .should()
+                .deleteMarketplaceListingById(LISTING_ID);
+    }
+
     private Player buyer(
             final int balance,
             final Item... items) {

--- a/src/test/java/com/amido/graphqltest/service/MarketplacePurchaseServiceImplTest.java
+++ b/src/test/java/com/amido/graphqltest/service/MarketplacePurchaseServiceImplTest.java
@@ -1,0 +1,161 @@
+package com.amido.graphqltest.service;
+
+import com.amido.graphqltest.domain.Item;
+import com.amido.graphqltest.domain.MarketplaceListing;
+import com.amido.graphqltest.domain.MarketplaceReceipt;
+import com.amido.graphqltest.domain.Player;
+import com.amido.graphqltest.exception.ItemAlreadyOwnedException;
+import com.amido.graphqltest.exception.ListingNotFoundException;
+import com.amido.graphqltest.exception.NotEnoughCurrencyException;
+import com.amido.graphqltest.exception.PlayerNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static com.amido.graphqltest.util.DomainExampleHelper.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+class MarketplacePurchaseServiceImplTest {
+
+    private final static String LISTING_ID = UUID.randomUUID().toString();
+    private final Clock clock = mock(Clock.class);
+    private final PlayerService playerService = mock(PlayerService.class);
+    private final MarketplaceListingService marketplaceListingService = mock(MarketplaceListingService.class);
+    private final MarketplacePurchaseServiceImpl marketplacePurchaseService = new MarketplacePurchaseServiceImpl(
+            clock,
+            playerService,
+            marketplaceListingService);
+
+    @BeforeEach
+    public void setUp() {
+        given(clock.instant())
+                .willReturn(Instant.now());
+    }
+
+    @Test
+    public void givenMarketPlaceListingNotFoundById_WhenPurchasingItem_ThenSellerShouldNotBeRetrieved() {
+        given(marketplaceListingService.findMarketplaceListingById(LISTING_ID))
+                .willThrow(new ListingNotFoundException("Listing with ID: " + LISTING_ID + " not found on marketplace."));
+
+        assertThatCode(() -> marketplacePurchaseService.buyItem(LISTING_ID, 2))
+                .isInstanceOf(ListingNotFoundException.class)
+                .hasMessage("Listing with ID: " + LISTING_ID + " not found on marketplace.");
+
+        verifyNoInteractions(playerService);
+    }
+
+    @Test
+    public void givenBuyerIsNotFoundById_WhenPurchasingItem_ThenExceptionShouldBeThrown() {
+        final int buyerId = 2;
+        given(marketplaceListingService.findMarketplaceListingById(LISTING_ID))
+                .willReturn(new MarketplaceListing());
+        given(playerService.findPlayerById(buyerId))
+                .willThrow(new PlayerNotFoundException("Player with id 2 not found"));
+
+        assertThatCode(() -> marketplacePurchaseService.buyItem(LISTING_ID, buyerId))
+                .isInstanceOf(PlayerNotFoundException.class)
+                .hasMessage("Player with id 2 not found");
+    }
+
+    @Test
+    public void givenListingAndBuyerAreFoundButBuyerDoesNotHaveEnoughCurrencyToBuy_WhenPurchasingItem_ThenNeitherPlayerShouldBeUpdated() {
+        final int buyerId = 2;
+        given(marketplaceListingService.findMarketplaceListingById(LISTING_ID))
+                .willReturn(testMarketplaceListingForRedPotion(LISTING_ID));
+        given(playerService.findPlayerById(buyerId))
+                .willReturn(buyer(100));
+
+        assertThatCode(() -> marketplacePurchaseService.buyItem(LISTING_ID, buyerId))
+                .isInstanceOf(NotEnoughCurrencyException.class)
+                .hasMessage("Insufficient balance to purchase listing");
+
+        then(playerService)
+                .should(never())
+                .updatePlayer(any());
+    }
+
+    @Test
+    public void givenBuyerAlreadyOwnsItem_WhenPurchasingItem_ThenNeitherPlayerShouldBeUpdated() {
+        final int buyerId = 2;
+        given(marketplaceListingService.findMarketplaceListingById(LISTING_ID))
+                .willReturn(testMarketplaceListingForRedPotion(LISTING_ID));
+        given(playerService.findPlayerById(buyerId))
+                .willReturn(buyer(200, redPotion()));
+
+        assertThatCode(() -> marketplacePurchaseService.buyItem(LISTING_ID, buyerId))
+                .isInstanceOf(ItemAlreadyOwnedException.class)
+                .hasMessage("You already own this item and cannot buy another");
+
+        then(playerService)
+                .should(never())
+                .updatePlayer(any());
+    }
+
+    @Test
+    public void givenPurchaseIsSuccessful_WhenPurchasingItem_ThenBuyerShouldHaveItemAndReducedCurrencyInReceipt() {
+        final int buyerId = 2;
+        final Player buyer = buyer(200);
+        final MarketplaceListing listing = testMarketplaceListingForRedPotion(LISTING_ID);
+        final Player seller = listing.getSeller();
+        given(marketplaceListingService.findMarketplaceListingById(LISTING_ID))
+                .willReturn(listing);
+        given(playerService.findPlayerById(buyerId))
+                .willReturn(buyer);
+        given(playerService.updatePlayer(seller))
+                .willReturn(testPlayerWithCurrency(200));
+        given(playerService.updatePlayer(buyer))
+                .willReturn(buyer(0, redPotion()));
+
+        final MarketplaceReceipt result = marketplacePurchaseService.buyItem(LISTING_ID, buyerId);
+
+        assertThat(result.getBuyer().getInventory())
+                .singleElement()
+                .satisfies(item -> {
+                    assertThat(item.getName())
+                            .isEqualTo("Red Potion");
+                });
+        assertThat(result.getBuyer().getCurrency())
+                .isEqualTo(0);
+    }
+
+    @Test
+    public void givenPurchaseIsSuccessful_WhenPurchasingItem_ThenSellerShouldHaveIncreasedCurrencyInReceipt() {
+        final int buyerId = 2;
+        final Player buyer = buyer(200);
+        final MarketplaceListing listing = testMarketplaceListingForRedPotion(LISTING_ID);
+        final Player seller = listing.getSeller();
+        given(marketplaceListingService.findMarketplaceListingById(LISTING_ID))
+                .willReturn(listing);
+        given(playerService.findPlayerById(buyerId))
+                .willReturn(buyer);
+        given(playerService.updatePlayer(seller))
+                .willReturn(testPlayerWithCurrency(200));
+        given(playerService.updatePlayer(buyer))
+                .willReturn(buyer(0, redPotion()));
+
+        final MarketplaceReceipt result = marketplacePurchaseService.buyItem(LISTING_ID, buyerId);
+
+        assertThat(result.getSeller().getCurrency())
+                .isEqualTo(200);
+    }
+
+    private Player buyer(
+            final int balance,
+            final Item... items) {
+        final Player buyer = new Player();
+        buyer.setId(2);
+        buyer.setCurrency(balance);
+        buyer.setInventory(Arrays.stream(items).collect(Collectors.toList()));
+        return buyer;
+    }
+
+}

--- a/src/test/java/com/amido/graphqltest/service/PlayerServiceImplTest.java
+++ b/src/test/java/com/amido/graphqltest/service/PlayerServiceImplTest.java
@@ -9,7 +9,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static com.amido.graphqltest.util.DomainExampleHelper.*;
+import static com.amido.graphqltest.util.DomainExampleHelper.redPotion;
+import static com.amido.graphqltest.util.DomainExampleHelper.testPlayer;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -91,7 +92,6 @@ class PlayerServiceImplTest {
                 .isInstanceOf(PlayerNotFoundException.class)
                 .hasMessage("Player with id 999999999 not found");
     }
-
 
 
 }

--- a/src/test/java/com/amido/graphqltest/service/PlayerServiceImplTest.java
+++ b/src/test/java/com/amido/graphqltest/service/PlayerServiceImplTest.java
@@ -1,6 +1,5 @@
 package com.amido.graphqltest.service;
 
-import com.amido.graphqltest.domain.Item;
 import com.amido.graphqltest.domain.Player;
 import com.amido.graphqltest.exception.PlayerNotFoundException;
 import com.amido.graphqltest.repository.PlayerRepository;
@@ -10,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static com.amido.graphqltest.util.DomainExampleHelper.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -57,7 +57,7 @@ class PlayerServiceImplTest {
     @Test
     public void givenPlayerISAdded_WhenPlayerAlreadyHasUsername_ThenExistingPlayerIsReturnedWithExistingInventory() {
         given(playerRepository.findByUsername("coolguy42"))
-                .willReturn(Optional.of(testPlayer()));
+                .willReturn(Optional.of(testPlayer(redPotion())));
 
         final Player result = playerService.addNewPlayer("coolguy42");
 
@@ -92,20 +92,6 @@ class PlayerServiceImplTest {
                 .hasMessage("Player with id 999999999 not found");
     }
 
-    private Player testPlayer() {
-        final Player player = new Player();
-        player.setId(1);
-        player.setLevel(12);
-        player.setUsername("coolguy42");
-        player.setInventory(Collections.singletonList(testItem()));
-        return player;
-    }
-
-    private Item testItem() {
-        final Item item = new Item();
-        item.setName("Red Potion");
-        return item;
-    }
 
 
 }

--- a/src/test/java/com/amido/graphqltest/util/DomainExampleHelper.java
+++ b/src/test/java/com/amido/graphqltest/util/DomainExampleHelper.java
@@ -1,6 +1,7 @@
 package com.amido.graphqltest.util;
 
 import com.amido.graphqltest.domain.Item;
+import com.amido.graphqltest.domain.MarketplaceListing;
 import com.amido.graphqltest.domain.Player;
 
 import java.util.Arrays;
@@ -17,11 +18,26 @@ public abstract class DomainExampleHelper {
         return player;
     }
 
+    public static Player testPlayerWithCurrency(final int balance, final Item... items) {
+        final Player player = testPlayer(items);
+        player.setCurrency(balance);
+        return player;
+    }
+
     public static Item redPotion() {
         final Item item = new Item();
         item.setId(1);
         item.setName("Red Potion");
         return item;
+    }
+
+    public static MarketplaceListing testMarketplaceListingForRedPotion(final String id){
+        final MarketplaceListing marketplaceListing = new MarketplaceListing();
+        marketplaceListing.setId(id);
+        marketplaceListing.setSeller(testPlayer());
+        marketplaceListing.setItem(redPotion());
+        marketplaceListing.setRequestedPrice(200);
+        return marketplaceListing;
     }
 
 }

--- a/src/test/java/com/amido/graphqltest/util/DomainExampleHelper.java
+++ b/src/test/java/com/amido/graphqltest/util/DomainExampleHelper.java
@@ -31,7 +31,7 @@ public abstract class DomainExampleHelper {
         return item;
     }
 
-    public static MarketplaceListing testMarketplaceListingForRedPotion(final String id){
+    public static MarketplaceListing testMarketplaceListingForRedPotion(final String id) {
         final MarketplaceListing marketplaceListing = new MarketplaceListing();
         marketplaceListing.setId(id);
         marketplaceListing.setSeller(testPlayer());

--- a/src/test/java/com/amido/graphqltest/util/DomainExampleHelper.java
+++ b/src/test/java/com/amido/graphqltest/util/DomainExampleHelper.java
@@ -1,0 +1,27 @@
+package com.amido.graphqltest.util;
+
+import com.amido.graphqltest.domain.Item;
+import com.amido.graphqltest.domain.Player;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public abstract class DomainExampleHelper {
+
+    public static Player testPlayer(final Item... inventoryItems) {
+        final Player player = new Player();
+        player.setId(1);
+        player.setLevel(12);
+        player.setUsername("coolguy42");
+        player.setInventory(Arrays.stream(inventoryItems).collect(Collectors.toList()));
+        return player;
+    }
+
+    public static Item redPotion() {
+        final Item item = new Item();
+        item.setId(1);
+        item.setName("Red Potion");
+        return item;
+    }
+
+}

--- a/src/test/resources/graphql/request/mutation/removePlayer.graphql
+++ b/src/test/resources/graphql/request/mutation/removePlayer.graphql
@@ -1,0 +1,3 @@
+mutation {
+    removePlayer(username: "john-doe")
+}


### PR DESCRIPTION
Pull request for: https://github.com/JasonDavies1/graphql-test/issues/2

This pull request closes the above issue allowing players to sell items between each other through a Marketplace. Players may create listings for items which other players may consume. Listings are stored in MariaDB. 

Once an item has been bought from the Marketplace a receipt for the transaction will be stored in Elasticsearch for archival purposes. 